### PR TITLE
Updated the type for utcOffset field from int to float64

### DIFF
--- a/authentication.go
+++ b/authentication.go
@@ -37,7 +37,7 @@ type Me struct {
 	Name                  string    `json:"name"`
 	StatusConnection      string    `json:"statusConnection"`
 	Username              string    `json:"username"`
-	UtcOffset             int       `json:"utcOffset"`
+	UtcOffset             float64   `json:"utcOffset"`
 	StatusText            string    `json:"statusText"`
 	Settings              Settings  `json:"settings"`
 	AvatarOrigin          string    `json:"avatarOrigin"`
@@ -124,7 +124,7 @@ type MeResponse struct {
 	Name                  string    `json:"name"`
 	StatusConnection      string    `json:"statusConnection"`
 	Username              string    `json:"username"`
-	UtcOffset             int       `json:"utcOffset"`
+	UtcOffset             float64   `json:"utcOffset"`
 	StatusText            string    `json:"statusText"`
 	Settings              Settings  `json:"settings"`
 	AvatarOrigin          string    `json:"avatarOrigin"`

--- a/users.go
+++ b/users.go
@@ -16,12 +16,12 @@ type UsersPresenceResponse struct {
 }
 
 type user struct {
-	ID         string `json:"_id"`
-	Name       string `json:"name"`
-	Username   string `json:"username"`
-	Status     string `json:"status"`
-	UtcOffset  int    `json:"utcOffset"`
-	AvatarETag string `json:"avatarETag"`
+	ID         string  `json:"_id"`
+	Name       string  `json:"name"`
+	Username   string  `json:"username"`
+	Status     string  `json:"status"`
+	UtcOffset  float64 `json:"utcOffset"`
+	AvatarETag string  `json:"avatarETag"`
 }
 
 type NewUser struct {
@@ -119,14 +119,14 @@ type UsersInfoResponse struct {
 }
 
 type singleUserInfo struct {
-	ID         string `json:"_id"`
-	Type       string `json:"type"`
-	Status     string `json:"status"`
-	Active     bool   `json:"active"`
-	Name       string `json:"name"`
-	UtcOffset  int    `json:"utcOffset"`
-	Username   string `json:"username"`
-	AvatarETag string `json:"avatarETag,omitempty"`
+	ID         string  `json:"_id"`
+	Type       string  `json:"type"`
+	Status     string  `json:"status"`
+	Active     bool    `json:"active"`
+	Name       string  `json:"name"`
+	UtcOffset  float64 `json:"utcOffset"`
+	Username   string  `json:"username"`
+	AvatarETag string  `json:"avatarETag,omitempty"`
 }
 
 type UserRegisterRequest struct {


### PR DESCRIPTION
The `utcOffset` can be a float number. For example, rocketchat sets 05+45 offset(which is the offset for Nepal) as 5.75

Previously, the `Me` struct looked like this.
```
type Me struct {
........
	UtcOffset             int   `json:"utcOffset"`
.......
}

```
***
This PR changes the struct into the following
```
type Me struct {
........
	UtcOffset             float64   `json:"utcOffset"`
.......
}
```

Similarly, this PR also updates `singleUserInfo` and `user` structs for the same field.

